### PR TITLE
Fix api prefix

### DIFF
--- a/Tasks/RenderApidocJsonTask.php
+++ b/Tasks/RenderApidocJsonTask.php
@@ -13,14 +13,17 @@ class RenderApidocJsonTask extends Task
 
     public function __construct(string $docType)
     {
+        //remove last '/' in api prefix
+        $apiPrefix = substr(config('apiato.api.prefix'), 0,-1);
+        
         $this->templatePath = 'Containers/' . config('vendor-documentation.section_name') . '/Documentation/ApiDocJs/' . $docType . '/apidoc.json';
         $this->outputPath = 'Containers/' . config('vendor-documentation.section_name') . '/Documentation/ApiDocJs/' . $docType . '/apidoc.json';
         $this->replaceArray = [
             'name' => config('app.name'),
             'description' => config('app.name') . ' (' . ucfirst($docType) . ' API) Documentation',
             'title' => 'Welcome to ' . config('app.name'),
-            'url' => config('apiato.api.url'),
-            'sampleUrl' => config('vendor-documentation.enable-sending-sample-request') ? config('apiato.api.url') : null,
+            'url' => config('apiato.api.url').$apiPrefix,
+            'sampleUrl' => config('vendor-documentation.enable-sending-sample-request') ? config('apiato.api.url').$apiPrefix : null,
         ];
     }
 


### PR DESCRIPTION
Add config('apiato.api.prefix') in url and sampleUrl

Its fix https://github.com/apiato/documentation-generator-container/issues/4 